### PR TITLE
Fix smirnoff

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -74,8 +74,8 @@ rule equilibrate:
     params:
         temperature = lambda wildcards: EXPERIMENTS[wildcards.identifier]["Temperature, K"],
     input:
-        prmtop = "results/tleap/{identifier}.prmtop",
-        inpcrd = "results/tleap/{identifier}.inpcrd",
+        prmtop = rules.build_box.output.prmtop,
+        inpcrd = rules.build_box.output.inpcrd,
     output:
         dcd = "results/equil/{identifier}.dcd",
         pdb = "results/equil/{identifier}.pdb",
@@ -92,8 +92,8 @@ rule production:
     params:
         temperature = lambda wildcards: EXPERIMENTS[wildcards.identifier]["Temperature, K"],
     input:
-        prmtop = "results/tleap/{identifier}.prmtop",
-        pdb = "results/equil/{identifier}.pdb",
+        prmtop = rules.build_box.output.prmtop,
+        pdb = rules.equilibrate.output.pdb,
     output:
         dcd = "results/production/{identifier}.dcd",
         csv = "results/production/{identifier}.csv",
@@ -124,10 +124,10 @@ rule generate_prediction:
         cas = lambda wildcards: EXPERIMENTS[wildcards.identifier]["cas"],
         temperature = lambda wildcards: EXPERIMENTS[wildcards.identifier]["Temperature, K"],
     input:
-        prmtop = "results/tleap/{identifier}.prmtop",
-        dcd = "results/production/{identifier}.dcd",
-        pdb = "results/equil/{identifier}.pdb",
-        csv = "results/production/{identifier}.csv",
+        prmtop = rules.build_box.output.prmtop,
+        dcd = rules.production.output.dcd,
+        pdb = rules.equilibrate.output.pdb,
+        csv = rules.production.output.csv,
     output:
         csv = "results/tables/predictions/{identifier}.csv",
     shell:
@@ -154,8 +154,8 @@ rule merge_predictions:
 
 rule plot_tbv:
     input:
-        pred_csv = "results/tables/predictions.csv",
-        data_with_metadata = "results/tables/data_with_metadata.csv",
+        pred_csv = rules.merge_predictions.output.csv,
+        data_with_metadata = rules.build_si_table.output.outcsv,
     output:
         dens_pdf = "results/figures/densities_thermoml.pdf",
         diff_pdf = "results/figures/densities_differences_thermoml.pdf",

--- a/code/density_simulation_parameters.py
+++ b/code/density_simulation_parameters.py
@@ -4,7 +4,7 @@ This file contains all simulation parameters used in this project.
 from simtk import unit as u
 
 
-MOLECULES_PER_BOX = 1000
+MOLECULES_PER_BOX = 500  # smirnoff eats up 16GB of RAM with 1,000 molecules
 
 CUTOFF = 0.95 * u.nanometers
 

--- a/code/lbrun.py
+++ b/code/lbrun.py
@@ -38,7 +38,7 @@ def build_box(in_mol2, in_frcmod, out_pdb, n_monomers, out_inpcrd, out_prmtop, f
     if ffxml is None:
         tleap_cmd = openmoltools.amber.build_mixture_prmtop(gaff_mol2_filenames, frcmod_filenames, out_pdb, out_prmtop, out_inpcrd)
     else:
-        tleap_cmd = smirnoffmixture.build_mixture_prmtop(gaff_mol2_filenames, frcmod_filenames, out_pdb, out_prmtop, out_inpcrd, ffxml=ffxml)
+        tleap_cmd = smirnoffmixture.build_mixture_prmtop(gaff_mol2_filenames, out_pdb, out_prmtop, out_inpcrd, ffxml=ffxml)
 
 
 def equilibrate(in_prmtop, in_inpcrd, out_dcd, out_pdb, temperature):

--- a/code/smirnoffmixture.py
+++ b/code/smirnoffmixture.py
@@ -5,7 +5,7 @@ from density_simulation_parameters import CUTOFF
 import parmed
 
 
-def build_mixture_prmtop(self, gaff_mol2_filenames, box_filename, prmtop_filename, inpcrd_filename, ffxml):
+def build_mixture_prmtop(gaff_mol2_filenames, box_filename, prmtop_filename, inpcrd_filename, ffxml):
     """Analog of openmoltools.amber.build_mixture_prmtop which uses SMIRNOFF forcefield (from github.com/open-forcefield-group/smarty) to parameterize small molecules, rather than GAFF.
 
 Parameters
@@ -36,7 +36,8 @@ You can use mdtraj to edit the residue names with something like
 this: trj.top.residue(0).name = "L1"
 """
     from openeye import oechem
-    from openforcefield.typing.engines.smirnoff import ForceField
+    from openforcefield.typing.engines.smirnoff import ForceField, PME
+    from openforcefield.utils import read_molecules, get_data_filename, generateTopologyFromOEMol
 
     # Read in molecules
     oemols = []
@@ -56,7 +57,7 @@ this: trj.top.residue(0).name = "L1"
     ff = ForceField(ffxml)
 
     # Construct system; charging not needed as mol2 files already have charges here
-    system = ff.createSystem(pdb.topology, oemols, nonbondedMethod=app.PME, nonbondedCutoff=CUTOFF)
+    system = ff.createSystem(pdb.topology, oemols, nonbondedMethod=PME, nonbondedCutoff=CUTOFF)
 
     # Dump to AMBER format
     structure = parmed.openmm.topsystem.load_topology(pdb.topology, system, pdb.positions)


### PR DESCRIPTION
1.  Fixed smirnoff issue observed in #1, was a typo on my end.
2.  Use sightly less redundant `rule.output.x` syntax to avoid retyping filenames in Snakefile
